### PR TITLE
CT-2245 Add audio only to VideoManagerMeta

### DIFF
--- a/lib/Interfaces/VideoInterface.php
+++ b/lib/Interfaces/VideoInterface.php
@@ -53,4 +53,6 @@ interface VideoInterface
     public function isPublished(): ?bool;
 
     public function isDownloadable(): ?bool;
+
+    public function isAudioOnly(): bool;
 }


### PR DESCRIPTION
This package is a dependency of another package.
I've added `isAudioOnly` method to the interface as this class https://github.com/MovingImage24/VMProApiClient/blob/master/lib/Entity/Video.php#L12 in another package implements that interface.